### PR TITLE
Fix: Cookies transferring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed cookies transferring between requests with different sessions.
 
 ## 0.5.0 - 2023-07-10
 ### Added

--- a/src/action/collect-cookies.mjs
+++ b/src/action/collect-cookies.mjs
@@ -11,6 +11,8 @@ export class CollectCookies extends AbstractAction {
         const client = await page.target().createCDPSession();
         const cookies = (await client.send('Storage.getCookies')).cookies;
 
+        await client.detach();
+
         for (let cookie of cookies) {
             const domain = cookie.domain.trim().replace(/^\./, '');
             const identity = sha256(cookie.name + '__' + domain);

--- a/src/crawler/crawler.mjs
+++ b/src/crawler/crawler.mjs
@@ -1,4 +1,5 @@
-import {PuppeteerCrawler, Configuration } from 'crawlee';
+import { Configuration } from 'crawlee';
+import { PuppeteerCrawler } from './puppeteer-crawler.mjs';
 import puppeteerExtra from 'puppeteer-extra';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import { ExecutionContext } from '../action/execution-context.mjs';
@@ -174,14 +175,6 @@ export class Crawler {
                     if (viewportOptions) {
                         await page.setViewport(viewportOptions);
                     }
-
-                    let cookiesToTransfer = request.userData.transferredCookies;
-
-                    if (0 >= cookiesToTransfer.length) {
-                        return;
-                    }
-
-                    await page.setCookie(...cookiesToTransfer);
                 },
             ],
         };

--- a/src/crawler/puppeteer-crawler.mjs
+++ b/src/crawler/puppeteer-crawler.mjs
@@ -1,0 +1,21 @@
+import { PuppeteerCrawler as CrawleePuppeteerCrawler } from 'crawlee';
+
+export class PuppeteerCrawler extends CrawleePuppeteerCrawler {
+    async _navigationHandler(crawlingContext, gotoOptions) {
+        const { page, request } = crawlingContext;
+
+        let cookiesToTransfer = request.userData.transferredCookies;
+
+        if (0 < cookiesToTransfer.length) {
+            const session = await page.target().createCDPSession();
+
+            await session.send('Network.setCookies', {
+                cookies: cookiesToTransfer,
+            });
+
+            await session.detach();
+        }
+
+        return super._navigationHandler(crawlingContext, gotoOptions);
+    }
+}


### PR DESCRIPTION
- fixed cookies transferring between requests with different sessions
- added class `PuppeteerCrawler` that is extended from Crawlee
- added deteaching of `CDPSession` in `CollectCookies` action
- updated CHANGELOG